### PR TITLE
Handle EPSG:3832 projection for vector tile layers in Map component

### DIFF
--- a/lib/components/map/index.tsx
+++ b/lib/components/map/index.tsx
@@ -34,6 +34,7 @@ import { SDMXMapConfig } from '../types';
 import RenderFeature from 'ol/render/Feature';
 import { isISO3Code, isoCountryCode3To2 } from '../../utils/isoCountryCode';
 import { getColorSchemeFunction, getColorSchemePreview, getReadableTextColor, getTextHaloColor } from '../../utils/mapColors';
+import TileGrid from 'ol/tilegrid/TileGrid';
 
 type MapDataLayer = VectorLayer<VectorSource> | VectorTileLayer
 
@@ -173,12 +174,24 @@ const MapComponent = ({ config, language, callback }: { config: SDMXMapConfig, l
     };
   }
 
-  const createInitialFeaturesLayer = (geojsonUrl: string) => {
+  const createInitialFeaturesLayer = (geojsonUrl: string, projection: string | null) => {
     let initialLayer: MapDataLayer;
     if (isVectorTileUrl(geojsonUrl)) {
+      // handle special case for EPSG:3832 used with a vector tile source - need to create custom tile grid and set it on the source for tiles to load correctly
+      let customTileGrid: TileGrid | undefined = undefined;
+      if (projection == "EPSG:3832") {
+        // create custom tilegrid
+        customTileGrid = new TileGrid({
+          extent: [-19628687.512850948, -8362698.548500745, 15807367.692644844, 10023392.492023032],
+          resolutions: [71820.668127046, 35910.334063523, 17955.167031761, 8977.5835158805, 4488.7917579403, 2244.3958789701, 1122.1979394851, 561.09896974255, 280.54948487127, 140.27474243563, 70.13737121782, 35.06868560891, 17.534342804455, 8.767171402227, 4.3835857011135, 2.1917928505567, 1.0958964252784, 0.5479482126392],
+          tileSize: 256
+        });
+      }
       const vectorTileSource = new VectorTileSource({
         format: new MVT(),
         url: geojsonUrl,
+        projection: projection || 'EPSG:3857',
+        tileGrid: customTileGrid
       });
       initialLayer = new VectorTileLayer({
         source: vectorTileSource,
@@ -251,7 +264,7 @@ const MapComponent = ({ config, language, callback }: { config: SDMXMapConfig, l
         mapRef.current.removeLayer(dataLayerRef.current)
       }
 
-      const initalFeaturesLayer = createInitialFeaturesLayer(dataObj.geojsonUrl)
+      const initalFeaturesLayer = createInitialFeaturesLayer(dataObj.geojsonUrl, dataObj.geojsonProjection)
 
       setFeaturesLayer(initalFeaturesLayer)
       dataLayerRef.current = initalFeaturesLayer

--- a/src/components/Maps.tsx
+++ b/src/components/Maps.tsx
@@ -24,7 +24,7 @@ const Maps = () => {
               },
               xAxisConcept: "GEO_PICT",
               colorScheme: "Oranges",
-              data: "https://stats-sdmx-disseminate.pacificdata.org/rest/data/DF_ENERGY/A...ENERGY_IND_011?dimensionAtObservation=AllDimensions&lastNObservations=1, {GEO_PICT} | https://geonode.pacificdata.org/geoserver/gwc/service/tms/1.0.0/geonode%3Aglobal_eez_200nm_split@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf, EPSG:3857, {iso_ter1}"
+              data: "https://stats-sdmx-disseminate.pacificdata.org/rest/data/DF_ENERGY/A...ENERGY_IND_011?dimensionAtObservation=AllDimensions&lastNObservations=1, {GEO_PICT} | https://geonode.pacificdata.org/geoserver/gwc/service/tms/1.0.0/geonode%3Aglobal_eez_200nm_split@EPSG%3A3832@pbf/{z}/{x}/{-y}.pbf, EPSG:3832, {iso_ter1}"
             }}
             language='en' />`
     }, {
@@ -76,7 +76,7 @@ const Maps = () => {
                 concept: "INDICATOR"
               },
               colorScheme: "Blues",
-              data: "https://stats-sdmx-disseminate.pacificdata.org/rest/data/SPC,DF_POP_PROJ,3.0/A.AS+CK+FJ+PF+GU+KI+MH+FM+NR+NC+NU+MP+PW+PG+PN+WS+SB+TK+TO+TV+VU+WF.MIDYEARPOPEST._T._T?startPeriod=2023&endPeriod=2023&dimensionAtObservation=AllDimensions, {GEO_PICT} | https://geonode.pacificdata.org/geoserver/gwc/service/tms/1.0.0/geonode%3Apacific_coastlines@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf, EPSG:3857, {iso_ter1_2}"
+              data: "https://stats-sdmx-disseminate.pacificdata.org/rest/data/SPC,DF_POP_PROJ,3.0/A.AS+CK+FJ+PF+GU+KI+MH+FM+NR+NC+NU+MP+PW+PG+PN+WS+SB+TK+TO+TV+VU+WF.MIDYEARPOPEST._T._T?startPeriod=2023&endPeriod=2023&dimensionAtObservation=AllDimensions, {GEO_PICT} | https://geonode.pacificdata.org/geoserver/gwc/service/tms/1.0.0/geonode%3Apacific_coastlines@EPSG%3A3832@pbf/{z}/{x}/{-y}.pbf, EPSG:3832, {iso_ter1_2}"
             }}
             language='en' />`
     }]


### PR DESCRIPTION

**Support for EPSG:3832 projection in vector tile layers:**

* Updated the `createInitialFeaturesLayer` function in `lib/components/map/index.tsx` to accept a `projection` parameter and, when `EPSG:3832` is detected, create and apply a custom `TileGrid` to the vector tile source created from the Geoserver gridset definition.

* Modified the map initialization logic to pass the projection from the data object to `createInitialFeaturesLayer`, ensuring the correct projection is used when creating the features layer.

**Demo and configuration updates:**

* Updated example map data in `src/components/Maps.tsx` to use vector tile sources with the `EPSG:3832` projection instead of `EPSG:3857`, demonstrating and testing the new projection support. [[1]](diffhunk://#diff-5f27b9ac24cf610410b5b51fa42f3e4a48d83553b49de75dedd1671c5a387a29L27-R27) [[2]](diffhunk://#diff-5f27b9ac24cf610410b5b51fa42f3e4a48d83553b49de75dedd1671c5a387a29L79-R79)